### PR TITLE
Update kentico.gitignore

### DIFF
--- a/kentico.gitignore
+++ b/kentico.gitignore
@@ -270,6 +270,7 @@ $RECYCLE.BIN/
 # Kentico temporary/environment files
 CMS/App_Data/AzureCache
 CMS/App_Data/AzureTemp
+CMS/App_Data/CMSModules/DeviceProfile/logFiftyOne.txt
 CMS/App_Data/CMSModules/DeviceProfiles/logFiftyOne.txt
 CMS/App_Data/CMSModules/WebFarm/webfarm.sync
 CMS/App_Data/CMSTemp

--- a/kentico.gitignore
+++ b/kentico.gitignore
@@ -270,7 +270,7 @@ $RECYCLE.BIN/
 # Kentico temporary/environment files
 CMS/App_Data/AzureCache
 CMS/App_Data/AzureTemp
-CMS/App_Data/CMSModules/DeviceProfile/logFiftyOne.txt
+CMS/App_Data/CMSModules/DeviceProfiles/logFiftyOne.txt
 CMS/App_Data/CMSModules/WebFarm/webfarm.sync
 CMS/App_Data/CMSTemp
 CMS/App_Data/Persistent


### PR DESCRIPTION
I noticed that when installing Kentico 10 the DeviceProfiles folder is plural and not singular "DeviceProfile". Unless this ignore file is for a different version of Kentico.