### PR TITLE
Modify .gitignore to ignore .vscode/

### DIFF
--- a/kentico.gitignore
+++ b/kentico.gitignore
@@ -24,6 +24,8 @@ bld/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+# Visual Studio Code configurations directory
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 


### PR DESCRIPTION
### Motivation

This commit removes generated files from source control. The files are generated by Visual Studio Code.

### Checklist

- [y] Code follows coding conventions held in this repo
- [n] Automated tests have been added
- [n] Tests are passing
- [y] Docu has been updated (if applicable)
- [y] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults

### How to test

1. Copy `kentico.gitignore` into the root of a Kentico solution
2. Rename `kentico.gitignore` to `.gitignore`
2. Run `git init` from the destination directory
3. Run `git add .gitignore; git commit -m "Add .gitignore"`
5. Run `git add *; git commit -m "Add project files"`
6. After the initial commits are complete, open the destination directory in VSCode then add a folder to the workspace. If `.vscode/` is ignored, then the new rule works.